### PR TITLE
Patch requirements file

### DIFF
--- a/python-reference-implementation/requirements.txt
+++ b/python-reference-implementation/requirements.txt
@@ -1,0 +1,1 @@
+pycrypto


### PR DESCRIPTION
Problem: Nowhere to know that pycrypto has to be installed to run setup.py test.

How to fix it: Requirements file that contains all data that needs to be installed to run it.